### PR TITLE
Ignore elements of resourcetype collection

### DIFF
--- a/carddav.php
+++ b/carddav.php
@@ -552,7 +552,8 @@ class CardDavBackend
 
         if (!empty($xml->response)) {
             foreach ($xml->response as $response) {
-                if (preg_match('/vcard/', $response->propstat->prop->getcontenttype) || preg_match('/vcf/', $response->href)) {
+              if ((preg_match('/vcard/', $response->propstat->prop->getcontenttype) || preg_match('/vcf/', $response->href)) &&
+                  !$response->propstat->prop->resourcetype->collection) {
                     $id = basename($response->href);
                     $id = str_replace($this->url_vcard_extension, null, $id);
 


### PR DESCRIPTION
Fix problem when reading data from [Radicale](http://radicale.org/).
Radicale includes a reference to the address book itself in the props list; querying it causes an exception to be thrown (since the result is not a valid vcard).
